### PR TITLE
Add missing err check for SessionBusPrivate() to prevent core dump

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -76,6 +76,9 @@ func SessionBus() (conn *Conn, err error) {
 		}
 	}()
 	conn, err = SessionBusPrivate()
+	if err != nil {
+		return
+	}
 	if err = conn.Auth(nil); err != nil {
 		conn.Close()
 		conn = nil


### PR DESCRIPTION
My server doesn't have dbus-launch command, and the examples crashed for me.

I'm doing a proof of concept evaluation of dbus connectivity using Go and your library.  Thanks for sharing! :smile:
