### PR TITLE
Enabling the support of interface{} in type signature

### DIFF
--- a/sig.go
+++ b/sig.go
@@ -101,6 +101,8 @@ func getSignature(t reflect.Type) string {
 			panic(InvalidTypeError{t})
 		}
 		return "a{" + getSignature(t.Key()) + getSignature(t.Elem()) + "}"
+	case reflect.Interface:
+		return "s"
 	}
 	panic(InvalidTypeError{t})
 }


### PR DESCRIPTION
There are some types, such as com.ubuntu.Upstart0_6.Instance.processes (http://upstart.ubuntu.com/wiki/DBusInterface) that don't have a direct mapping and are considered as interface{} by the library. This fix allows to consider those as string, to be able to access the data in it. Current behavior is panicking with an InvalidTypeError.
