### PR TITLE
Use launchctl to obtain session bus address on OS X

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,11 +1,9 @@
 package dbus
 
 import (
-	"bytes"
 	"errors"
 	"io"
 	"os"
-	"os/exec"
 	"reflect"
 	"strings"
 	"sync"
@@ -97,17 +95,8 @@ func SessionBusPrivate() (*Conn, error) {
 	if address != "" && address != "autolaunch:" {
 		return Dial(address)
 	}
-	cmd := exec.Command("dbus-launch")
-	b, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, err
-	}
-	i := bytes.IndexByte(b, '=')
-	j := bytes.IndexByte(b, '\n')
-	if i == -1 || j == -1 {
-		return nil, errors.New("dbus: couldn't determine address of session bus")
-	}
-	return Dial(string(b[i+1 : j]))
+
+	return SessionBusPlatform()
 }
 
 // SystemBus returns a shared connection to the system bus, connecting to it if
@@ -558,9 +547,6 @@ type Signal struct {
 type transport interface {
 	// Read and Write raw data (for example, for the authentication protocol).
 	io.ReadWriteCloser
-
-	// Send the initial null byte used for the EXTERNAL mechanism.
-	SendNullByte() error
 
 	// Returns whether this transport supports passing Unix FDs.
 	SupportsUnixFDs() bool

--- a/conn_darwin.go
+++ b/conn_darwin.go
@@ -1,0 +1,16 @@
+package dbus
+
+import (
+	"os/exec"
+)
+
+func SessionBusPlatform() (*Conn, error) {
+	cmd := exec.Command("launchctl", "getenv", "DBUS_LAUNCHD_SESSION_BUS_SOCKET")
+	b, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return Dial("unix:path=" + string(b[:len(b)-1]))
+}

--- a/conn_other.go
+++ b/conn_other.go
@@ -1,0 +1,26 @@
+// +build !darwin
+
+package dbus
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+func SessionBusPlatform() (*Conn, error) {
+	cmd := exec.Command("dbus-launch")
+	b, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return nil, err
+	}
+
+	i := bytes.IndexByte(b, '=')
+	j := bytes.IndexByte(b, '\n')
+
+	if i == -1 || j == -1 {
+		return nil, errors.New("dbus: couldn't determine address of session bus")
+	}
+
+	return Dial(string(b[i+1 : j]))
+}


### PR DESCRIPTION
The "standard" way to launch dbus on OS X is through launchd which
is responsible for allocating a unix domain socket and then passing
it to dbus. This patch splits out a platform specific method to obtain
the session bus if DBUS_SESSION_BUS_ADDRESS is not set. On OS X
launchctl is queried while on other platforms dbus-launch is used
as before.
