### PR TITLE
Only send unix credentials on !darwin

### DIFF
--- a/transport_darwin.go
+++ b/transport_darwin.go
@@ -1,0 +1,7 @@
+package dbus
+
+func (t *unixTransport) SendNullByte() error {
+	_, err := t.Write([]byte{0})
+	return err
+}
+

--- a/transport_unix.go
+++ b/transport_unix.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net"
-	"os"
 	"syscall"
 )
 
@@ -182,19 +181,6 @@ func (t *unixTransport) SendMessage(msg *Message) error {
 		if err := msg.EncodeTo(t, binary.LittleEndian); err != nil {
 			return nil
 		}
-	}
-	return nil
-}
-
-func (t *unixTransport) SendNullByte() error {
-	ucred := &syscall.Ucred{Pid: int32(os.Getpid()), Uid: uint32(os.Getuid()), Gid: uint32(os.Getgid())}
-	b := syscall.UnixCredentials(ucred)
-	_, oobn, err := t.UnixConn.WriteMsgUnix([]byte{0}, b, nil)
-	if err != nil {
-		return err
-	}
-	if oobn != len(b) {
-		return io.ErrShortWrite
 	}
 	return nil
 }

--- a/transport_unixcred.go
+++ b/transport_unixcred.go
@@ -1,0 +1,23 @@
+// +build !darwin
+
+package dbus
+
+import (
+	"io"
+	"os"
+	"syscall"
+)
+
+func (t *unixTransport) SendNullByte() error {
+	ucred := &syscall.Ucred{Pid: int32(os.Getpid()), Uid: uint32(os.Getuid()), Gid: uint32(os.Getgid())}
+	b := syscall.UnixCredentials(ucred)
+	_, oobn, err := t.UnixConn.WriteMsgUnix([]byte{0}, b, nil)
+	if err != nil {
+		return err
+	}
+	if oobn != len(b) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+


### PR DESCRIPTION
This patch will send a simple null byte without
unix credentials on the darwin platform. For all
other platforms, the Ucred syscall is used as
before.
