### PR TITLE
Send uid rather than username when authenticating via EXTERN

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -56,7 +56,7 @@ func (conn *Conn) Auth(methods []Auth) error {
 		if err != nil {
 			return err
 		}
-		methods = []Auth{AuthExternal(u.Username), AuthCookieSha1(u.Username, u.HomeDir)}
+		methods = []Auth{AuthExternal(u.Uid), AuthCookieSha1(u.Username, u.HomeDir)}
 	}
 	in := bufio.NewReader(conn.transport)
 	err := conn.transport.SendNullByte()


### PR DESCRIPTION
This helps in docker where the /etc/passwd on the container side
may not match the host one, so verification will fail. There is
no advantage of giving the username here anyway, its just less
efficient.
