### PR TITLE
Honor introspection calls on sub path of every exported object

### DIFF
--- a/export.go
+++ b/export.go
@@ -61,6 +61,23 @@ func (conn *Conn) handleCall(msg *Message) {
 			conn.sendError(errmsgUnknownMethod, sender, serial)
 		}
 		return
+	} else if ifaceName == "org.freedesktop.DBus.Introspectable" && name == "Introspect" {
+		if _, ok := conn.handlers[path]; !ok {
+			xml := "<node>"
+			for h, _ := range conn.handlers {
+				p := string(path)
+				if p != "/" {
+					p += "/"
+				}
+				if strings.HasPrefix(string(h), p) {
+					node_name := strings.Split(string(h[len(p):]), "/")[0]
+					xml = xml + "\n    <node name=\"" + node_name + "\"/>"
+				}
+			}
+			xml += "\n</node>"
+			conn.sendReply(sender, serial, xml)
+			return
+		}
 	}
 	if len(name) == 0 || unicode.IsLower([]rune(name)[0]) {
 		conn.sendError(errmsgUnknownMethod, sender, serial)


### PR DESCRIPTION
This allows introspection based tools such as D-feet to correctly find their way
towards exported objects, starting from /

e.g., if two objects are exported under path /a/b/c and /d/e/f, an Introspect
call on / will return nodes a and d, while an call on /a will return b, and /d
will return e. This allows going from / all the way to /a/b/c and /d/e/f,
withouth knowing anything about the exported objects in the first place.
