### PR TITLE
Fix encoding alignment logic.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>)
+Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), Google
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/encoder.go
+++ b/encoder.go
@@ -16,22 +16,41 @@ type encoder struct {
 
 // NewEncoder returns a new encoder that writes to out in the given byte order.
 func newEncoder(out io.Writer, order binary.ByteOrder) *encoder {
+	return newEncoderAtOffset(out, 0, order)
+}
+
+// newEncoderAtOffset returns a new encoder that writes to out in the given
+// byte order. Specify the offset to initialize pos for proper alignment
+// computation.
+func newEncoderAtOffset(out io.Writer, offset int, order binary.ByteOrder) *encoder {
 	enc := new(encoder)
 	enc.out = out
 	enc.order = order
+	enc.pos = offset
 	return enc
 }
 
 // Aligns the next output to be on a multiple of n. Panics on write errors.
 func (enc *encoder) align(n int) {
-	if enc.pos%n != 0 {
-		newpos := (enc.pos + n - 1) & ^(n - 1)
-		empty := make([]byte, newpos-enc.pos)
+	pad := enc.padding(0, n)
+	if pad > 0 {
+		empty := make([]byte, pad)
 		if _, err := enc.out.Write(empty); err != nil {
 			panic(err)
 		}
-		enc.pos = newpos
+		enc.pos += pad
 	}
+}
+
+// pad returns the number of bytes of padding, based on current position and additional offset.
+// and alignment.
+func (enc *encoder) padding(offset, algn int) int {
+	abs := enc.pos + offset
+	if abs%algn != 0 {
+		newabs := (abs + algn - 1) & ^(algn - 1)
+		return newabs - abs
+	}
+	return 0
 }
 
 // Calls binary.Write(enc.out, enc.order, v) and panics on write errors.
@@ -108,8 +127,11 @@ func (enc *encoder) encode(v reflect.Value, depth int) {
 		if depth >= 64 {
 			panic(FormatError("input exceeds container depth limit"))
 		}
+		// Lookahead offset: 4 bytes for uint32 length, plus alignment
+		offset := enc.pos + 4 + enc.padding(4, alignment(v.Type().Elem()))
+
 		var buf bytes.Buffer
-		bufenc := newEncoder(&buf, enc.order)
+		bufenc := newEncoderAtOffset(&buf, offset, enc.order)
 
 		for i := 0; i < v.Len(); i++ {
 			bufenc.encode(v.Index(i), depth+1)
@@ -159,8 +181,11 @@ func (enc *encoder) encode(v reflect.Value, depth int) {
 			panic(InvalidTypeError{v.Type()})
 		}
 		keys := v.MapKeys()
+		// Lookahead offset: 4 bytes for uint32 length, plus 8-byte alignment
+		offset := enc.pos + 4 + enc.padding(4, 8)
+
 		var buf bytes.Buffer
-		bufenc := newEncoder(&buf, enc.order)
+		bufenc := newEncoderAtOffset(&buf, offset, enc.order)
 		for _, k := range keys {
 			bufenc.align(8)
 			bufenc.encode(k, depth+2)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,58 @@
+package dbus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+	"testing"
+)
+
+func TestEncodeArrayOfMaps(t *testing.T) {
+	tests := []struct {
+		name string
+		vs   []interface{}
+	}{
+		{
+			"aligned at 8 at start of array",
+			[]interface{}{
+				"12345",
+				[]map[string]Variant{
+					{
+						"abcdefg": MakeVariant("foo"),
+						"cdef":    MakeVariant(uint32(2)),
+					},
+				},
+			},
+		},
+		{
+			"not aligned at 8 for start of array",
+			[]interface{}{
+				"1234567890",
+				[]map[string]Variant{
+					{
+						"abcdefg": MakeVariant("foo"),
+						"cdef":    MakeVariant(uint32(2)),
+					},
+				},
+			},
+		},
+	}
+	for _, order := range []binary.ByteOrder{binary.LittleEndian, binary.BigEndian} {
+		for _, tt := range tests {
+			buf := new(bytes.Buffer)
+			enc := newEncoder(buf, order)
+			enc.Encode(tt.vs...)
+
+			dec := newDecoder(buf, order)
+			v, err := dec.Decode(SignatureOf(tt.vs...))
+			if err != nil {
+				t.Errorf("%q: decode (%v) failed: %v", tt.name, order, err)
+				continue
+			}
+			if !reflect.DeepEqual(v, tt.vs) {
+				t.Errorf("%q: (%v) not equal: got '%v', want '%v'", tt.name, order, v, tt.vs)
+				continue
+			}
+		}
+	}
+}


### PR DESCRIPTION
The newEncoder method is recursive, but alignment logic must be based on
"global" absolute position. This FIX allows recursive calls to set the
initial position.

Unit tests added to very the problem and fix.

The problem was discovered for nested containers where the start of the
nested container can be on a 4-byte-aligned (but not 8-byte-aligned) boundary.