### PR TITLE
Handle empty SASL handshake to fix "dbus: authentication failed"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+go.mod
+go.sum

--- a/README.markdown
+++ b/README.markdown
@@ -30,6 +30,22 @@ gives a short overview over the basic usage.
 Please note that the API is considered unstable for now and may change without
 further notice.
 
+### Local development
+
+To work with a local copy for development, run
+
+```
+go mod init
+go mod tidy
+```
+
+then in your own `go.mod`, assuming you checked out `go.dbus` in your project
+directory:
+
+```
+replace github.com/guelfey/go.dbus => ./go.dbus
+```
+
 ### License
 
 go.dbus is available under the Simplified BSD License; see LICENSE for the full

--- a/auth.go
+++ b/auth.go
@@ -6,7 +6,12 @@ import (
 	"errors"
 	"io"
 	"os/user"
+	"log"
 )
+
+// For debug purposes the dbus.TraceAuth flag may be set to "true"
+// by the client.
+var TraceAuth bool = false
 
 // AuthStatus represents the Status of an authentication mechanism.
 type AuthStatus byte
@@ -224,12 +229,27 @@ func authReadLine(in *bufio.Reader) ([][]byte, error) {
 		return nil, err
 	}
 	data = bytes.TrimSuffix(data, []byte("\r\n"))
-	return bytes.Split(data, []byte{' '}), nil
+	fields := bytes.Split(data, []byte{' '})
+	if (TraceAuth) {
+		log.Print("authReadLine():")
+		for _, v := range fields {
+			log.Print("    ", string(v))
+		}
+	}
+	return fields, nil
+
 }
 
 // authWriteLine writes the given line in the authentication protocol format
 // (elements of data separated by a " " and terminated by "\r\n").
 func authWriteLine(out io.Writer, msg []byte, data ...[]byte) error {
+	if (TraceAuth) {
+		log.Print("authWriteLine():")
+		log.Print("    ", msg)
+		for _, v := range data {
+			log.Print("    ", string(v))
+		}
+	}
 	buf := make([]byte, 0)
 	buf = append(buf, msg...)
 	if (len(data) > 0) {

--- a/auth.go
+++ b/auth.go
@@ -42,7 +42,7 @@ type Auth interface {
 
 	// Process the given DATA command, and return the argument to the DATA
 	// command and the next status. If len(resp) == 0, no DATA command is sent.
-	HandleData(data []byte) (resp []byte, status AuthStatus)
+	HandleData(data [][]byte) (resp [][]byte, status AuthStatus)
 }
 
 // Auth authenticates the connection, trying the given list of authentication
@@ -79,17 +79,21 @@ func (conn *Conn) Auth(methods []Auth) error {
 		for _, m := range methods {
 			if name, data, status := m.FirstData(); bytes.Equal(v, name) {
 				var ok bool
-				err = authWriteLine(conn.transport, []byte("AUTH"), []byte(v), data)
+				if (data != nil) {
+					err = authWriteLine(conn.transport, []byte("AUTH"), []byte(v), data)
+				} else {
+					err = authWriteLine(conn.transport, []byte("AUTH"), []byte(v))
+				}
 				if err != nil {
 					return err
 				}
 				switch status {
-				case AuthOk:
-					err, ok = conn.tryAuth(m, waitingForOk, in)
-				case AuthContinue:
-					err, ok = conn.tryAuth(m, waitingForData, in)
-				default:
-					panic("dbus: invalid authentication status")
+					case AuthOk:
+						err, ok = conn.tryAuth(m, waitingForOk, in)
+					case AuthContinue:
+						err, ok = conn.tryAuth(m, waitingForData, in)
+					default:
+						panic("dbus: invalid authentication status")
 				}
 				if err != nil {
 					return err
@@ -105,12 +109,12 @@ func (conn *Conn) Auth(methods []Auth) error {
 							return err
 						}
 						switch {
-						case bytes.Equal(line[0], []byte("AGREE_UNIX_FD")):
-							conn.EnableUnixFDs()
-							conn.unixFD = true
-						case bytes.Equal(line[0], []byte("ERROR")):
-						default:
-							return errors.New("dbus: authentication protocol error")
+							case bytes.Equal(line[0], []byte("AGREE_UNIX_FD")):
+								conn.EnableUnixFDs()
+								conn.unixFD = true
+							case bytes.Equal(line[0], []byte("ERROR")):
+							default:
+								return errors.New("dbus: authentication protocol error")
 						}
 					}
 					err = authWriteLine(conn.transport, []byte("BEGIN"))
@@ -139,21 +143,12 @@ func (conn *Conn) tryAuth(m Auth, state authState, in *bufio.Reader) (error, boo
 		}
 		switch {
 		case state == waitingForData && string(s[0]) == "DATA":
-			if len(s) != 2 {
-				err = authWriteLine(conn.transport, []byte("ERROR"))
-				if err != nil {
-					return err, false
-				}
-				continue
-			}
-			data, status := m.HandleData(s[1])
+			data, status := m.HandleData(s[1:])
 			switch status {
 			case AuthOk, AuthContinue:
-				if len(data) != 0 {
-					err = authWriteLine(conn.transport, []byte("DATA"), data)
-					if err != nil {
-						return err, false
-					}
+				err = authWriteLine(conn.transport, []byte("DATA"), data...)
+				if err != nil {
+					return err, false
 				}
 				if status == AuthOk {
 					state = waitingForOk
@@ -234,8 +229,12 @@ func authReadLine(in *bufio.Reader) ([][]byte, error) {
 
 // authWriteLine writes the given line in the authentication protocol format
 // (elements of data separated by a " " and terminated by "\r\n").
-func authWriteLine(out io.Writer, data ...[]byte) error {
+func authWriteLine(out io.Writer, msg []byte, data ...[]byte) error {
 	buf := make([]byte, 0)
+	buf = append(buf, msg...)
+	if (len(data) > 0) {
+		buf = append(buf, ' ')
+	}
 	for i, v := range data {
 		buf = append(buf, v...)
 		if i != len(data)-1 {

--- a/auth_external.go
+++ b/auth_external.go
@@ -1,7 +1,6 @@
 package dbus
 
 import (
-	"encoding/hex"
 )
 
 // AuthExternal returns an Auth that authenticates as the given user with the
@@ -16,11 +15,14 @@ type authExternal struct {
 }
 
 func (a authExternal) FirstData() ([]byte, []byte, AuthStatus) {
-	b := make([]byte, 2*len(a.user))
-	hex.Encode(b, []byte(a.user))
-	return []byte("EXTERNAL"), b, AuthOk
+	//b := make([]byte, 2*len(a.user))
+	//hex.Encode(b, []byte(a.user))
+	return []byte("EXTERNAL"), nil, AuthContinue
 }
 
-func (a authExternal) HandleData(b []byte) ([]byte, AuthStatus) {
-	return nil, AuthError
+func (a authExternal) HandleData(data [][]byte) ([][]byte, AuthStatus) {
+	if (len(data) != 0) {
+		return nil, AuthError
+	}
+	return nil, AuthOk
 }

--- a/auth_sha1.go
+++ b/auth_sha1.go
@@ -26,7 +26,11 @@ func (a authCookieSha1) FirstData() ([]byte, []byte, AuthStatus) {
 	return []byte("DBUS_COOKIE_SHA1"), b, AuthContinue
 }
 
-func (a authCookieSha1) HandleData(data []byte) ([]byte, AuthStatus) {
+func (a authCookieSha1) HandleData(fields [][]byte) ([][]byte, AuthStatus) {
+	if (len(fields) != 1) {
+		return nil, AuthError
+	}
+	data := fields[0]
 	challenge := make([]byte, len(data)/2)
 	_, err := hex.Decode(challenge, data)
 	if err != nil {
@@ -55,7 +59,7 @@ func (a authCookieSha1) HandleData(data []byte) ([]byte, AuthStatus) {
 	data = append(data, hexhash...)
 	resp := make([]byte, 2*len(data))
 	hex.Encode(resp, data)
-	return resp, AuthOk
+	return [][]byte{resp}, AuthOk
 }
 
 // getCookie searches for the cookie identified by id in context and returns


### PR DESCRIPTION
See issue #68 for details.

This pull request incorporates the proposed fix for #68 as seen in the commit message for 9c4d13f, as well as an option to trace the protocol exchange during authentication and a small README change.